### PR TITLE
修复“IE中点击确定按钮之后报错，导致不能截图”的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^16.7.0"
   },
   "dependencies": {
+    "canvas-toBlob": "^1.0.0",
     "react-image-crop": "^6.0.12"
   },
   "devDependencies": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,24 @@ import ReactCrop, { getPixelCrop } from 'react-image-crop';
 import { Modal } from 'antd';
 import './index.scss';
 
+// 修复IE中 canvas.toBlob() 报错
+import 'canvas-toBlob';
+
+// 修复IE中 new File() 报错
+try {
+  new File([], '');
+} catch (e) {
+  /* eslint-disable-next-line */
+  File = class File extends Blob {
+    constructor(chunks, filename, opts = {}) {
+      super(chunks, opts);
+      this.lastModifiedDate = new Date();
+      this.lastModified = +this.lastModifiedDate;
+      this.name = filename;
+    }
+  };
+}
+
 const defaultState = {
   // Modal
   modalVisible: false,


### PR DESCRIPTION
修复IE中 canvas.toBlob() 报错
修复IE中 new File() 报错