### PR TITLE
Quick fix for Safari redraw bug

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -137,6 +137,18 @@ const ImgCrop = forwardRef((props, ref) => {
             const reader = new FileReader();
             reader.addEventListener('load', () => {
               setSrc(reader.result);
+              /*
+              *  fix redraw bug for Safari where the
+              *  crop size could be wrong caused possibly
+              *  by the modal animation
+              */
+              const stop = Date.now() + 600
+              let animInt = setInterval(() => {
+                setRotateVal(0.1)
+                setRotateVal(0)
+                if(Date.now() - stop >= 0) clearInterval(animInt)
+              }, 30)
+              
             });
             reader.readAsDataURL(file);
           }),


### PR DESCRIPTION
In Safari (at least in 13.1.2 on desktop) after choosing an image the crop area would be too small the first time. Only a browser window resize would fix it. This forces the crop area size to be recalculated during the time when the modal is appearing.