### PR TITLE
fix: 将 Blob 对象转为 File 对象

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -231,10 +231,11 @@ const ImgCrop = forwardRef((props, ref) => {
     const { type, name, uid } = fileRef.current;
     canvas.toBlob(
       async (blob) => {
-        let newFile = blob;
+        let newFile = new window.File([blob], name, { type: type });
+        // let newFile = blob;
 
-        newFile.lastModifiedDate = Date.now();
-        newFile.name = name;
+        // newFile.lastModifiedDate = Date.now();
+        // newFile.name = name;
         newFile.uid = uid;
 
         if (typeof beforeUploadRef.current !== 'function') return resolveRef.current(newFile);


### PR DESCRIPTION
如果服务端没有做兼容，直接传Blob对象会失败。因此，先将Blob 对象转为 File 对象，再上传才能成功