### PR TITLE
add cropSize attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ const Demo = () => (
 | ----------- | -------------------- | -------------- | --------------------------------------------------------- |
 | aspect      | `number`             | `1 / 1`        | Aspect of crop area , `width / height`                    |
 | shape       | `string`             | `'rect'`       | Shape of crop area, `'rect'` or `'round'`                 |
+| cropSize    | `{ width: number, height: number }`   | - | Size of the crop area (in pixels). If you don't provide it, it will be computed automatically using the aspect prop and the media size.
 | grid        | `boolean`            | `false`        | Show grid of crop area (third-lines)                      |
 | zoom        | `boolean`            | `true`         | Enable zoom for image                                     |
 | rotate      | `boolean`            | `false`        | Enable rotate for image                                   |

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,10 @@ export interface ImgCropProps {
   aspect?: number;
   shape?: 'rect' | 'round';
   grid?: boolean;
+  cropSize?: {
+    width: number,
+    height: number,
+  };
 
   zoom?: boolean;
   rotate?: boolean;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,6 +23,7 @@ const EasyCrop = forwardRef((props, ref) => {
     aspect,
     shape,
     grid,
+    cropSize,
 
     hasZoom,
     zoomVal,
@@ -51,6 +52,7 @@ const EasyCrop = forwardRef((props, ref) => {
       crop={crop}
       onCropChange={setCrop}
       aspect={aspect}
+      cropSize={cropSize}
       cropShape={shape}
       showGrid={grid}
       zoomWithScroll={hasZoom}
@@ -71,6 +73,10 @@ EasyCrop.propTypes = {
   aspect: t.number,
   shape: t.string,
   grid: t.bool,
+  cropSize: t.shape({
+    width: t.number,
+    height: t.number,
+  }),
 
   hasZoom: t.bool,
   zoomVal: t.number,
@@ -88,6 +94,7 @@ const ImgCrop = forwardRef((props, ref) => {
     aspect,
     shape,
     grid,
+    cropSize,
 
     zoom,
     rotate,
@@ -286,6 +293,7 @@ const ImgCrop = forwardRef((props, ref) => {
             aspect={aspect}
             shape={shape}
             grid={grid}
+            cropSize={cropSize}
             hasZoom={hasZoom}
             zoomVal={zoomVal}
             rotateVal={rotateVal}
@@ -347,6 +355,10 @@ ImgCrop.propTypes = {
   aspect: t.number,
   shape: t.oneOf(['rect', 'round']),
   grid: t.bool,
+  cropSize: t.shape({
+    width: t.number,
+    height: t.number,
+  }),
 
   zoom: t.bool,
   rotate: t.bool,


### PR DESCRIPTION
Hi,
I need to expose the cropSize attribute of react-easy-crop to force the size of the crop.
Let me know if I can do something else to improve the PR!

Thanks for your amazing work
Niccolò