### PR TITLE
Add cropper props as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ const Demo = () => (
 | modalOk     | `string`             | `'OK'`         | Text of confirm button of modal                           |
 | modalCancel | `string`             | `'Cancel'`     | Text of cancel button of modal                            |
 | beforeCrop  | `function`           | -              | Call before modal open, if return `false`, it'll not open |
+| cropperProps| `object`             | -              | Object of props for [react-easy-crop](https://www.npmjs.com/package/react-easy-crop). [List of Props](https://github.com/ricardo-ch/react-easy-crop#props)  |
 
 ## Styles
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,6 +48,7 @@ const Demo = () => (
 | modalOk     | `string`             | `'确定'`     | 弹窗确定按钮文字                               |
 | modalCancel | `string`             | `'取消'`     | 弹窗取消按钮文字                               |
 | beforeCrop  | `function`           | -            | 弹窗打开前调用，若返回 `false`，弹框将不会打开 |
+| cropperProps| `object`             | -             | 道具对象 [react-easy-crop](https://www.npmjs.com/package/react-easy-crop). [道具清单](https://github.com/ricardo-ch/react-easy-crop#props)  |
 
 ## 样式
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { CropperProps } from 'react-easy-crop';
 
 export interface ImgCropProps {
   aspect?: number;
@@ -16,6 +17,8 @@ export interface ImgCropProps {
   modalCancel?: string;
 
   beforeCrop?: (file: File, fileList: File[]) => boolean;
+
+  cropperProps: CropperProps
 }
 declare const ImgCrop: React.FC<ImgCropProps>;
 export default ImgCrop;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "react-easy-crop": "^3.1.1"
+    "react-easy-crop": "^3.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -33,6 +33,8 @@ const EasyCrop = forwardRef((props, ref) => {
     minZoom,
     maxZoom,
     onComplete,
+
+    cropperProps,
   } = props;
 
   const [crop, setCrop] = useState({ x: 0, y: 0 });
@@ -46,6 +48,7 @@ const EasyCrop = forwardRef((props, ref) => {
 
   return (
     <Cropper
+      {...cropperProps}
       ref={ref}
       image={src}
       crop={crop}
@@ -81,6 +84,8 @@ EasyCrop.propTypes = {
   minZoom: t.number,
   maxZoom: t.number,
   onComplete: t.func,
+
+  cropperProps: t.object,
 };
 
 const ImgCrop = forwardRef((props, ref) => {
@@ -101,6 +106,8 @@ const ImgCrop = forwardRef((props, ref) => {
 
     beforeCrop,
     children,
+
+    cropperProps,
   } = props;
 
   const hasZoom = zoom === true;
@@ -294,6 +301,7 @@ const ImgCrop = forwardRef((props, ref) => {
             minZoom={minZoom}
             maxZoom={maxZoom}
             onComplete={onComplete}
+            cropperProps={cropperProps}
           />
           {hasZoom && (
             <div className={`${pkg}-control zoom`}>
@@ -360,6 +368,8 @@ ImgCrop.propTypes = {
 
   beforeCrop: t.func,
   children: t.node,
+
+  cropperProps: t.object,
 };
 
 ImgCrop.defaultProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2920,12 +2920,12 @@ rc-virtual-list@^3.0.1, rc-virtual-list@^3.0.3:
     rc-resize-observer "^0.2.3"
     rc-util "^5.0.7"
 
-react-easy-crop@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-easy-crop/-/react-easy-crop-3.1.1.tgz#e5f5d8d42540be7ab1ddb8c79927b9f75ee6ec43"
-  integrity sha512-q5NYzFyzMNbTg/hYLc74lWl/uuQPbWAvge0MUywkLdAuc2A6KxKWplcMBHGQg3dVGqMqnpu7TMDgiZboJOFkbA==
+react-easy-crop@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-3.2.1.tgz#b72f553a04815fa1bcfdd1ccf1be68dfd6699d5f"
+  integrity sha512-5igouY5tKFckQHdKl5fDq2uT3dq6cEC/V+a2OvgVs6Hh9LxeE7vQvrAoOHsHzH7CnlSnen+KW3Mb4HkQs9qr2A==
   dependencies:
-    tslib "1.11.2"
+    tslib "2.0.1"
 
 react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -3330,10 +3330,10 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
-  integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
+tslib@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
 tslib@^1.10.0, tslib@^1.8.1:
   version "1.13.0"


### PR DESCRIPTION
This PR just expose cropper props as an option allowing you to set props on nest library. 

Enabling any of the props available on React Easy Crop: [https://www.npmjs.com/package/react-easy-crop#props](https://www.npmjs.com/package/react-easy-crop#props)

Main reason for me was to allow setting restrictPosition when I set zoom level below 1.