### PR TITLE
fix:修复组件使用时父组件没有使用Model或Slider时的antd样式文件缺失

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,7 +3,9 @@ import t from 'prop-types';
 import Cropper from 'react-easy-crop';
 import LocaleReceiver from 'antd/es/locale-provider/LocaleReceiver';
 import Modal from 'antd/es/modal';
+import 'antd/es/modal/style/css';
 import Slider from 'antd/es/slider';
+import 'antd/es/slider/style/css';
 import './index.less';
 
 const pkg = 'antd-img-crop';


### PR DESCRIPTION
使用antd-img-crop组件时，若父组件中没有使用antd的Modal或Slider组件，则该组件会缺失样式