### PR TITLE
Add resizeMaxSize props to set a max image size and resize it (issue #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,24 @@ const Demo = () => (
 
 ## Props
 
-| Prop         | Type                 | Default        | Description                                                           |
-| ------------ | -------------------- | -------------- | --------------------------------------------------------------------- |
-| aspect       | `number`             | `1 / 1`        | Aspect of crop area , `width / height`                                |
-| shape        | `string`             | `'rect'`       | Shape of crop area, `'rect'` or `'round'`                             |
-| grid         | `boolean`            | `false`        | Show grid of crop area (third-lines)                                  |
-| quality      | `number`             | `0.4`          | Image quality, `0 ~ 1`                                                |
-| fillColor    | `string`             | `white`        | Fill color when cropped image smaller than canvas                     |
-| zoom         | `boolean`            | `true`         | Enable zoom for image                                                 |
-| rotate       | `boolean`            | `false`        | Enable rotate for image                                               |
-| minZoom      | `number`             | `1`            | Minimum zoom factor                                                   |
-| maxZoom      | `number`             | `3`            | Maximum zoom factor                                                   |
-| modalTitle   | `string`             | `'Edit image'` | Title of modal                                                        |
-| modalWidth   | `number` \| `string` | `520`          | Width of modal in pixels number or percentages                        |
-| modalOk      | `string`             | `'OK'`         | Text of confirm button of modal                                       |
-| modalCancel  | `string`             | `'Cancel'`     | Text of cancel button of modal                                        |
-| beforeCrop   | `function`           | -              | Call before modal open, if return `false`, it'll not open             |
-| cropperProps | `object`             | -              | Props of [react-easy-crop] (\* [existing props] cannot be overridden) |
+| Prop          | Type                 | Default        | Description                                                           |
+| ------------- | -------------------- | -------------- | --------------------------------------------------------------------- |
+| aspect        | `number`             | `1 / 1`        | Aspect of crop area , `width / height`                                |
+| shape         | `string`             | `'rect'`       | Shape of crop area, `'rect'` or `'round'`                             |
+| grid          | `boolean`            | `false`        | Show grid of crop area (third-lines)                                  |
+| quality       | `number`             | `0.4`          | Image quality, `0 ~ 1`                                                |
+| fillColor     | `string`             | `white`        | Fill color when cropped image smaller than canvas                     |
+| zoom          | `boolean`            | `true`         | Enable zoom for image                                                 |
+| rotate        | `boolean`            | `false`        | Enable rotate for image                                               |
+| minZoom       | `number`             | `1`            | Minimum zoom factor                                                   |
+| maxZoom       | `number`             | `3`            | Maximum zoom factor                                                   |
+| resizeMaxSize | `number`             | -              | Maximum image width or height                                         |
+| modalTitle    | `string`             | `'Edit image'` | Title of modal                                                        |
+| modalWidth    | `number` \| `string` | `520`          | Width of modal in pixels number or percentages                        |
+| modalOk       | `string`             | `'OK'`         | Text of confirm button of modal                                       |
+| modalCancel   | `string`             | `'Cancel'`     | Text of cancel button of modal                                        |
+| beforeCrop    | `function`           | -              | Call before modal open, if return `false`, it'll not open             |
+| cropperProps  | `object`             | -              | Props of [react-easy-crop] (\* [existing props] cannot be overridden) |
 
 ## Styles
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export interface ImgCropProps {
   rotate?: boolean;
   minZoom?: number;
   maxZoom?: number;
+  resizeMaxSize?: number;
 
   modalTitle?: string;
   modalWidth?: number | string;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.1",
+    "pica": "^6.1.1",
     "react-easy-crop": "^3.3.0"
   },
   "devDependencies": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -334,7 +334,7 @@ const ImgCrop = forwardRef((props, ref) => {
       type,
       quality
     );
-  }, [hasRotate, onClose, quality, rotateVal]);
+  }, [hasRotate, onClose, quality, rotateVal, fillColor]);
 
   const renderComponent = (titleOfModal) => (
     <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,6 +1972,11 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+glur@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/glur/-/glur-1.1.2.tgz#f20ea36db103bfc292343921f1f91e83c3467689"
+  integrity sha1-8g6jbbEDv8KSNDkh8fkeg8NGdok=
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
@@ -2047,7 +2052,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2342,6 +2347,14 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+multimath@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/multimath/-/multimath-2.0.0.tgz#0d37acf67c328f30e3d8c6b0d3209e6082710302"
+  integrity sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g==
+  dependencies:
+    glur "^1.1.2"
+    object-assign "^4.1.1"
+
 native-request@^1.0.5:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/native-request/-/native-request-1.0.8.tgz#8f66bf606e0f7ea27c0e5995eb2f5d03e33ae6fb"
@@ -2509,6 +2522,16 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+pica@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/pica/-/pica-6.1.1.tgz#5219d70265bf34926f656e42268b14ddba5c734b"
+  integrity sha512-dmjQheDGFOl+30rQhN3NM3MyDNjeOZvco6IL3ZVYgyVDmhgvcSCGOAsydRCIaZ36mcXO7ci0XFeD+h6unEcBvA==
+  dependencies:
+    inherits "^2.0.3"
+    multimath "^2.0.0"
+    object-assign "^4.1.1"
+    webworkify "^1.5.0"
 
 picomatch@^2.2.2:
   version "2.2.2"
@@ -3488,6 +3511,11 @@ warning@^4.0.1, warning@^4.0.3:
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
+
+webworkify@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/webworkify/-/webworkify-1.5.0.tgz#734ad87a774de6ebdd546e1d3e027da5b8f4a42c"
+  integrity sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Hello!

Thanks a lot for your work on this project.

I'm using it and after some days in production, we started to face the same problem as related in issue #55. After investigating it for a while, I found out this problem is related to the easy-react-crop and Safari.
There is a limit of memory used for drawing canvas, and several users have related this issue in the react-easy-crop:

[https://github.com/ricardo-ch/react-easy-crop/issues/98]
[https://github.com/ricardo-ch/react-easy-crop/issues/91]
[https://github.com/ricardo-ch/react-easy-crop/issues/147]

The only possible solution suggested to get rid of it is resizing the image before cropping.

Since the beforeCrop() implemented here does not allow to modify the file itself, I thought that would be great if we could set a limit of width our height, and adjust resize the file.
To do it, I'm using the Pica, which can deal with the IOS problems nicely.
[https://github.com/nodeca/pica/wiki/iOS-Memory-Limit]

Feel free to make any suggestions in the code or in the approach.