### PR TITLE
Fix the asynchronous validation in beforeCrop

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -157,8 +157,8 @@ const ImgCrop = forwardRef((props, ref) => {
         ...restUploadProps,
         accept: accept || 'image/*',
         beforeUpload: (file, fileList) =>
-          new Promise((resolve, reject) => {
-            if (beforeCrop && !beforeCrop(file, fileList)) {
+          new Promise(async (resolve, reject) => {
+            if (beforeCrop && !(await beforeCrop(file, fileList))) {
               reject();
               return;
             }


### PR DESCRIPTION
Due to beforeCrop not being async I am not able to do some validations that can only be done asynchronously.
This pr fix that problem by making beforeCrop compatible with async await 