### PR TITLE
fix issue with cropper not getting correct width and height

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,29 @@ const Demo = () => (
 
 ## Props
 
-| Prop          | Type                 | Default        | Description                                                           |
-| ------------- | -------------------- | -------------- | --------------------------------------------------------------------- |
-| aspect        | `number`             | `1 / 1`        | Aspect of crop area , `width / height`                                |
-| shape         | `string`             | `'rect'`       | Shape of crop area, `'rect'` or `'round'`                             |
-| grid          | `boolean`            | `false`        | Show grid of crop area (third-lines)                                  |
-| quality       | `number`             | `0.4`          | Image quality, `0 ~ 1`                                                |
-| fillColor     | `string`             | `'white'`      | Fill color when cropped image smaller than canvas                     |
-| zoom          | `boolean`            | `true`         | Enable zoom for image                                                 |
-| rotate        | `boolean`            | `false`        | Enable rotate for image                                               |
-| minZoom       | `number`             | `1`            | Minimum zoom factor                                                   |
-| maxZoom       | `number`             | `3`            | Maximum zoom factor                                                   |
-| modalTitle    | `string`             | `'Edit image'` | Title of modal                                                        |
-| modalWidth    | `number` \| `string` | `520`          | Width of modal in pixels number or percentages                        |
-| modalOk       | `string`             | `'OK'`         | Text of modal confirm button                                          |
-| modalCancel   | `string`             | `'Cancel'`     | Text of modal cancel button                                           |
-| onModalOk     | `function`           | -              | Call when click modal confirm button                                  |
-| onModalCancel | `function`           | -              | Call when click modal mask, top right "x", or cancel button           |
-| beforeCrop    | `function`           | -              | Call before modal open, if return `false`, it'll not open             |
-| onUploadFail  | `function`           | -              | Call when upload failed                                               |
-| cropperProps  | `object`             | -              | Props of [react-easy-crop] (\* [existing props] cannot be overridden) |
+| Prop                    | Type                 | Default        | Description                                                                              |
+| ----------------------- | -------------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| aspect                  | `number`             | `1 / 1`        | Aspect of crop area , `width / height`                                                   |
+| shape                   | `string`             | `'rect'`       | Shape of crop area, `'rect'` or `'round'`                                                |
+| grid                    | `boolean`            | `false`        | Show grid of crop area (third-lines)                                                     |
+| quality                 | `number`             | `0.4`          | Image quality, `0 ~ 1`                                                                   |
+| fillColor               | `string`             | `'white'`      | Fill color when cropped image smaller than canvas                                        |
+| zoom                    | `boolean`            | `true`         | Enable zoom for image                                                                    |
+| rotate                  | `boolean`            | `false`        | Enable rotate for image                                                                  |
+| minZoom                 | `number`             | `1`            | Minimum zoom factor                                                                      |
+| maxZoom                 | `number`             | `3`            | Maximum zoom factor                                                                      |
+| modalTitle              | `string`             | `'Edit image'` | Title of modal                                                                           |
+| modalWidth              | `number` \| `string` | `520`          | Width of modal in pixels number or percentages                                           |
+| modalOk                 | `string`             | `'OK'`         | Text of modal confirm button                                                             |
+| modalCancel             | `string`             | `'Cancel'`     | Text of modal cancel button                                                              |
+| modalMaskTransitionName | `string`             | `'fade'`       | MaskTransitionName of modal, use `'none'` to disable the default modal transition effect |
+| modalTransitionName     | `string`             | `'fade'`       | TransitionName of modal, use `'none'` to disable the default modal transition effect     |
+| modalCancel             | `string`             | `'Cancel'`     | Text of modal cancel button                                                              |
+| onModalOk               | `function`           | -              | Call when click modal confirm button                                                     |
+| onModalCancel           | `function`           | -              | Call when click modal mask, top right "x", or cancel button                              |
+| beforeCrop              | `function`           | -              | Call before modal open, if return `false`, it'll not open                                |
+| onUploadFail            | `function`           | -              | Call when upload failed                                                                  |
+| cropperProps            | `object`             | -              | Props of [react-easy-crop] (\* [existing props] cannot be overridden)                    |
 
 ## Styles
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,26 +37,28 @@ const Demo = () => (
 
 ## Props
 
-| 属性          | 类型                 | 默认         | 说明                                                   |
-| ------------- | -------------------- | ------------ | ------------------------------------------------------ |
-| aspect        | `number`             | `1 / 1`      | 裁切区域宽高比，`width / height`                       |
-| shape         | `string`             | `'rect'`     | 裁切区域形状，`'rect'` 或 `'round'`                    |
-| grid          | `boolean`            | `false`      | 显示裁切区域网格（九宫格）                             |
-| quality       | `number`             | `0.4`        | 图片质量，`0 ~ 1`                                      |
-| fillColor     | `string`             | `'white'`    | 裁切图像小于画布时的填充颜色                           |
-| zoom          | `boolean`            | `true`       | 启用图片缩放                                           |
-| rotate        | `boolean`            | `false`      | 启用图片旋转                                           |
-| minZoom       | `number`             | `1`          | 最小缩放倍数                                           |
-| maxZoom       | `number`             | `3`          | 最大缩放倍数                                           |
-| modalTitle    | `string`             | `'编辑图片'` | 弹窗标题                                               |
-| modalWidth    | `number` \| `string` | `520`        | 弹窗宽度，`px` 的数值或百分比                          |
-| modalOk       | `string`             | `'确定'`     | 弹窗确定按钮文字                                       |
-| modalCancel   | `string`             | `'取消'`     | 弹窗取消按钮文字                                       |
-| onModalOK     | `function`           | -            | 点击弹窗确定回调                                       |
-| onModalCancel | `function`           | -            | 点击弹窗遮罩层、右上角叉、取消的回调                   |
-| beforeCrop    | `function`           | -            | 弹窗打开前调用，若返回 `false`，弹框将不会打开         |
-| onUploadFail  | `function`           | -            | 上传失败时的回调                                       |
-| cropperProps  | `object`             | -            | [react-easy-crop] 的 props（\* [已有 props] 无法重写） |
+| 属性                    | 类型                 | 默认         | 说明                                                           |
+| ----------------------- | -------------------- | ------------ | -------------------------------------------------------------- |
+| aspect                  | `number`             | `1 / 1`      | 裁切区域宽高比，`width / height`                               |
+| shape                   | `string`             | `'rect'`     | 裁切区域形状，`'rect'` 或 `'round'`                            |
+| grid                    | `boolean`            | `false`      | 显示裁切区域网格（九宫格）                                     |
+| quality                 | `number`             | `0.4`        | 图片质量，`0 ~ 1`                                              |
+| fillColor               | `string`             | `'white'`    | 裁切图像小于画布时的填充颜色                                   |
+| zoom                    | `boolean`            | `true`       | 启用图片缩放                                                   |
+| rotate                  | `boolean`            | `false`      | 启用图片旋转                                                   |
+| minZoom                 | `number`             | `1`          | 最小缩放倍数                                                   |
+| maxZoom                 | `number`             | `3`          | 最大缩放倍数                                                   |
+| modalTitle              | `string`             | `'编辑图片'` | 弹窗标题                                                       |
+| modalWidth              | `number` \| `string` | `520`        | 弹窗宽度，`px` 的数值或百分比                                  |
+| modalOk                 | `string`             | `'确定'`     | 弹窗确定按钮文字                                               |
+| modalCancel             | `string`             | `'取消'`     | 弹窗取消按钮文字                                               |
+| modalMaskTransitionName | `string`             | `'fade'`     | 弹窗掩码过渡名称, 将其设置为 `'none'` 以禁用默认的模态过渡效果 |
+| modalTransitionName     | `string`             | `'fade'`     | 弹窗过渡名称, 将其设置为 `'none'` 以禁用默认的模态过渡效果     |
+| onModalOK               | `function`           | -            | 点击弹窗确定回调                                               |
+| onModalCancel           | `function`           | -            | 点击弹窗遮罩层、右上角叉、取消的回调                           |
+| beforeCrop              | `function`           | -            | 弹窗打开前调用，若返回 `false`，弹框将不会打开                 |
+| onUploadFail            | `function`           | -            | 上传失败时的回调                                               |
+| cropperProps            | `object`             | -            | [react-easy-crop] 的 props（\* [已有 props] 无法重写）         |
 
 ## 样式
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,8 @@ export interface ImgCropProps {
   modalWidth?: number | string;
   modalOk?: string;
   modalCancel?: string;
+  modalMaskTransitionName?: string;
+  modalTransitionName?: string;
   onModalOk?: (file: void | boolean | string | Blob | File) => void;
   onModalCancel?: () => void;
 

--- a/src/img-crop.tsx
+++ b/src/img-crop.tsx
@@ -27,6 +27,8 @@ const ImgCrop = forwardRef<Cropper, ImgCropProps>((props, ref) => {
     modalWidth,
     modalOk,
     modalCancel,
+    modalMaskTransitionName,
+    modalTransitionName,
     onModalOk,
     onModalCancel,
 
@@ -101,12 +103,18 @@ const ImgCrop = forwardRef<Cropper, ImgCropProps>((props, ref) => {
    * Modal
    */
   const modalProps = useMemo(() => {
-    const obj = { width: modalWidth, okText: modalOk, cancelText: modalCancel };
+    const obj = {
+      width: modalWidth,
+      okText: modalOk,
+      cancelText: modalCancel,
+      maskTransitionName: modalMaskTransitionName,
+      transitionName: modalTransitionName,
+    };
     Object.keys(obj).forEach((key) => {
       if (!obj[key]) delete obj[key];
     });
     return obj;
-  }, [modalCancel, modalOk, modalWidth]);
+  }, [modalCancel, modalOk, modalWidth, modalMaskTransitionName, modalTransitionName]);
 
   const onClose = () => {
     setImage('');


### PR DESCRIPTION
Ref issues:
1. https://github.com/nanxiaobei/antd-img-crop/issues/177
2. https://github.com/nanxiaobei/antd-img-crop/issues/181

Because Ant Modal includes some transition effects and that might be the cause for this issue as the image is rendered in parallel and it might have loaded faster than the modal completing its transition.

With these attributes, we disable the transition/motion so the modal is loaded as soon as the image: https://ant.design/components/modal/#How-to-disable-motion