### PR TITLE
Add in capability for modal to accept you own defined classname

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ const Demo = () => (
 | modalCancel             | `string`             | `'Cancel'`     | Text of modal cancel button                                                        |
 | modalMaskTransitionName | `string`             | `'fade'`       | MaskTransitionName of modal, use `'none'` to disable the default transition effect |
 | modalTransitionName     | `string`             | `'fade'`       | TransitionName of modal, use `'none'` to disable the default transition effect     |
+| modalClassName          | `string`             | `''`           | Provide your own classname for the Modal container                                 |
 | onModalOk               | `function`           | -              | Call when click modal confirm button                                               |
 | onModalCancel           | `function`           | -              | Call when click modal mask, top right "x", or cancel button                        |
 | beforeCrop              | `function`           | -              | Call before modal open, if return `false`, it'll not open                          |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,6 +53,7 @@ const Demo = () => (
 | modalOk                 | `string`             | `'确定'`     | 弹窗确定按钮文字                                       |
 | modalCancel             | `string`             | `'取消'`     | 弹窗取消按钮文字                                       |
 | modalMaskTransitionName | `string`             | `'fade'`     | 弹窗遮罩过渡效果, 设为 `'none'` 可禁用默认过渡效果     |
+| modalClassName          | `string`             | `''`         | 为 Modal 容器提供您自己的类名                           |
 | modalTransitionName     | `string`             | `'fade'`     | 弹窗过渡效果, 设为 `'none'` 可禁用默认过渡效果         |
 | onModalOK               | `function`           | -            | 点击弹窗确定回调                                       |
 | onModalCancel           | `function`           | -            | 点击弹窗遮罩层、右上角叉、取消的回调                   |

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ export interface ImgCropProps {
   modalOk?: string;
   modalCancel?: string;
   modalMaskTransitionName?: string;
+  modalClassName?: string;
   modalTransitionName?: string;
   onModalOk?: (file: void | boolean | string | Blob | File) => void;
   onModalCancel?: () => void;

--- a/src/img-crop.tsx
+++ b/src/img-crop.tsx
@@ -30,6 +30,7 @@ const ImgCrop = forwardRef<Cropper, ImgCropProps>((props, ref) => {
     modalCancel,
     modalMaskTransitionName,
     modalTransitionName,
+    modalClassName,
     onModalOk,
     onModalCancel,
 
@@ -231,7 +232,7 @@ const ImgCrop = forwardRef<Cropper, ImgCropProps>((props, ref) => {
       {image && (
         <AntModal
           visible={true}
-          wrapClassName={`${PREFIX}-modal`}
+          wrapClassName={`${PREFIX}-modal ${modalClassName || ''}`}
           title={titleOfModal}
           onOk={onOk}
           onCancel={onCancel}


### PR DESCRIPTION
I noticed there was a previous issue where someone else needed to add a custom classname for the Modal. I have a similar requirement where I am using CSS variables based on a parent classname theme. I am needing to apply a custom classname theme to the modal so that the correct CSS variables can be applied