### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd-img-crop",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "An image cropper for Ant Design Upload",
   "keywords": [
     "react",


### PR DESCRIPTION
Unable to consume the last PR update to add in `modalClassName` unless the version is bumped for npm package