### PR TITLE
fix: 根据 antd 版本是否在 4.23.0 之前去选择使用 visible 或 open

### DIFF
--- a/src/ImgCrop.tsx
+++ b/src/ImgCrop.tsx
@@ -11,10 +11,12 @@ import LocaleReceiver from 'antd/es/locale-provider/LocaleReceiver';
 import type Cropper from 'react-easy-crop';
 import type { UploadProps } from 'antd';
 import type { RcFile } from 'antd/lib/upload';
+import { version as AntdVersion } from 'antd';
 import type { ImgCropProps } from '../index';
 import type { EasyCropHandle } from './EasyCrop';
 import { PREFIX, INIT_ZOOM, INIT_ROTATE } from './constants';
 import EasyCrop from './EasyCrop';
+import { compareVersion } from './helper';
 import './ImgCrop.less';
 
 const ImgCrop = forwardRef<Cropper, ImgCropProps>((props, ref) => {
@@ -269,13 +271,14 @@ const ImgCrop = forwardRef<Cropper, ImgCropProps>((props, ref) => {
     );
   }, [fillColor, quality, rotate]);
 
+  const visibleProp = compareVersion(AntdVersion, "4.23.0") === -1 ? { visible: true } : { open: true }
+
   const getComponent = (titleOfModal) => (
     <>
       {uploadComponent}
       {image && (
         <AntModal
-          open={true}
-          visible={true}
+          {...visibleProp}
           wrapClassName={`${PREFIX}-modal ${modalClassName || ''}`}
           title={titleOfModal}
           onOk={onOk}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,0 +1,33 @@
+export function compareVersion(version1: string, version2: string) {
+    const arr1 = version1.split('.')
+    const arr2 = version2.split('.')
+    const length1 = arr1.length
+    const length2 = arr2.length
+    const minlength = Math.min(length1, length2)
+    let i = 0
+    for (i ; i < minlength; i++) {
+      let a = parseInt(arr1[i])
+      let b = parseInt(arr2[i])
+      if (a > b) {
+        return 1
+      } else if (a < b) {
+        return -1
+      }
+    }
+    if (length1 > length2) {
+      for(let j = i; j < length1; j++) {
+        if (parseInt(arr1[j]) !== 0) {
+          return 1
+        }
+      }
+      return 0
+    } else if (length1 < length2) {
+      for(let j = i; j < length2; j++) {
+        if (parseInt(arr2[j]) !== 0) {
+          return -1
+        }
+      }
+      return 0
+    }
+    return 0
+  }


### PR DESCRIPTION
目前 open 和 visible 并行仍然会报 [antd: Modal] `visible` will be removed in next major version, please use `open` instead 的错误