### PR TITLE
Wrap modal with custom ConfigProvider

### DIFF
--- a/src/ImgCrop.tsx
+++ b/src/ImgCrop.tsx
@@ -2,6 +2,8 @@ import type { ModalProps } from 'antd';
 import { version } from 'antd';
 import AntModal from 'antd/es/modal';
 import AntUpload from 'antd/es/upload';
+import AntTheme from 'antd/es/theme';
+import AntConfigProvider from 'antd/es/config-provider';
 import type { RcFile, UploadFile } from 'antd/es/upload/interface';
 import { compareVersions } from 'compare-versions';
 import type { MouseEvent, ReactNode } from 'react';
@@ -31,6 +33,7 @@ const deprecate = (obj: Record<string, any>, old: string, now: string) => {
 
 const ImgCrop = forwardRef<CropperRef, ImgCropProps>((props, cropperRef) => {
   const {
+    theme,
     quality = 0.4,
     fillColor = 'white',
 
@@ -347,34 +350,38 @@ const ImgCrop = forwardRef<CropperRef, ImgCropProps>((props, cropperRef) => {
     <>
       {getNewUpload(children)}
       {modalImage && (
-        <AntModal
-          {...modalProps}
-          {...modalBaseProps}
-          {...{ [openProp]: true }}
-          title={title}
-          onCancel={onCancel.current}
-          onOk={onOk.current}
-          wrapClassName={wrapClassName}
-          maskClosable={false}
-          destroyOnClose
+        <AntConfigProvider 
+          theme={theme ?? AntTheme.defaultConfig}
         >
-          <EasyCrop
-            ref={easyCropRef}
-            cropperRef={cropperRef}
-            zoomSlider={zoomSlider}
-            rotationSlider={rotationSlider}
-            aspectSlider={aspectSlider}
-            showReset={showReset}
-            resetBtnText={resetBtnText}
-            modalImage={modalImage}
-            aspect={aspect}
-            minZoom={minZoom}
-            maxZoom={maxZoom}
-            cropShape={cropShape}
-            showGrid={showGrid}
-            cropperProps={cropperProps}
-          />
-        </AntModal>
+          <AntModal
+            {...modalProps}
+            {...modalBaseProps}
+            {...{ [openProp]: true }}
+            title={title}
+            onCancel={onCancel.current}
+            onOk={onOk.current}
+            wrapClassName={wrapClassName}
+            maskClosable={false}
+            destroyOnClose
+          >
+            <EasyCrop
+              ref={easyCropRef}
+              cropperRef={cropperRef}
+              zoomSlider={zoomSlider}
+              rotationSlider={rotationSlider}
+              aspectSlider={aspectSlider}
+              showReset={showReset}
+              resetBtnText={resetBtnText}
+              modalImage={modalImage}
+              aspect={aspect}
+              minZoom={minZoom}
+              maxZoom={maxZoom}
+              cropShape={cropShape}
+              showGrid={showGrid}
+              cropperProps={cropperProps}
+            />
+          </AntModal>
+        </AntConfigProvider>
       )}
     </>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { ModalProps, UploadProps } from 'antd';
+import type { ModalProps, UploadProps, ThemeConfig } from 'antd';
 import type { ForwardedRef, MutableRefObject } from 'react';
 import type { default as Cropper, CropperProps } from 'react-easy-crop';
 import type { Area } from 'react-easy-crop/types';
@@ -7,6 +7,7 @@ export type BeforeUpload = Exclude<UploadProps['beforeUpload'], undefined>;
 export type BeforeUploadReturnType = ReturnType<BeforeUpload>;
 
 export type ImgCropProps = {
+  theme?: ThemeConfig
   quality?: number;
   fillColor?: string;
 


### PR DESCRIPTION
This will really fix issue #272 
For me, using NextJs it's working nice.

I also deleted my`.babelrc` and theme keeps working so there's no need to add bellow code anymore:
```
module.exports = {
  presets: [ require.resolve( 'next/babel' ) ],
  plugins: [
    [ 'import', { libraryName: 'antd', libraryDirectory: 'lib', style: true } ]
  ]
}
```

What I've done is wrapping cropper modal with a `ConfigProvider` and allow user to pass his current `theme` settings.

Usage will be somenthing like this:
```
// create somewhere (in my case I have a theme context) theme config
const currentTheme = {
  algorithm: isDark? darkAlgorithm : defaultAlgorithm,
  token: {
    ......
  }
}

// pass it to cropper component
<ImgCrop
  theme={ currentTheme }
  ...{other props}
>
  <Upload />
</ImgCrop>
```