### PR TITLE
types update: make cropperProps.keyboardStep optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,8 @@ export type ImgCropProps = {
     | 'onRotationChange'
     | 'onCropComplete'
     | 'classes'
-  >;
+    | 'keyboardStep'
+  > & Partial<Pick<CropperProps, 'keyboardStep'>>;
 
   modalClassName?: string;
   modalTitle?: string;


### PR DESCRIPTION
cropperProps.keyboardStep is required prop in latest(4.24) version cause react-easy-crop add it, this pull request make it optional.