### PR TITLE
fix: add useEffect to set aspect

### DIFF
--- a/src/EasyCrop.tsx
+++ b/src/EasyCrop.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   memo,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -70,6 +71,10 @@ const EasyCrop = forwardRef<EasyCropRef, EasyCropProps>((props, ref) => {
     cropPixelsRef,
     onReset,
   }));
+
+  useEffect(() => {
+    setAspect(ASPECT_INITIAL);
+  }, [ASPECT_INITIAL]);
 
   const wrapperClass =
     '[display:flex] [align-items:center] [width:60%] [margin-inline:auto]';


### PR DESCRIPTION
如果想在组件外层动态的修改 aspect的值，原来的能力无法做到，aspect 只会在第一次的时候设置有效，例如

```tsx
const [aspect, setAspect] = useState<number>(4 / 3)
<ImgCrop
  aspect={aspect}
  modalProps={{
    footer: (
      <div className="flex flex-row justify-center w-full items-center gap-3">
        <Button onClick={() => setAspect(1 / 1)}>1:1</Button>
        <Button onClick={() => setAspect(4 / 3)}>4:3</Button>
        <Button onClick={() => setAspect(16 / 9)}>16:9</Button>
      </div>
    ),
  }}
>
  <AntdUpload
    action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
    listType="picture-card"
    fileList={fileList}
    onChange={onChange}
    onPreview={onPreview}
  >
    {fileList.length < 5 && "+ Upload"}
  </AntdUpload>
</ImgCrop>
```
点击按钮设置不同的 aspect值，但是弹窗中的比例并不会改变，原因是 ImgCrop组件内部会把 aspect 值当成初始值。
组件位置: src/EasyCrop.tsx  👇
<img width="630" alt="image" src="https://github.com/user-attachments/assets/dda58ea1-7e7f-4129-8349-b560299a3fc2" />

调整后：
使用 useEffect 对 aspect做监听，当外部组件传入新的 aspect值，会让组件内的 aspect 修改生效
