### PR TITLE
Add exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
   "main": "dist/antd-img-crop.cjs.js",
   "module": "dist/antd-img-crop.esm.js",
   "types": "dist/antd-img-crop.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/antd-img-crop.d.ts",
+      "import": "./dist/antd-img-crop.esm.js",
+      "require": "./dist/antd-img-crop.cjs.js"
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixes #320.

This pull request introduces an `exports` field to the `package.json` file, which helps define explicit entry points for different module systems (ESM and CommonJS) and type definitions. This change improves compatibility and clarity for consumers of the package. 

- Packaging and module resolution:
  * Added an `exports` field to `package.json` to specify entry points for type definitions, ESM imports, and CommonJS requires.